### PR TITLE
Clean up force:org:snapshot examples in messages files

### DIFF
--- a/messages/shape.create.json
+++ b/messages/shape.create.json
@@ -7,8 +7,8 @@
   "create_shape_command_description": "Create a scratch org configuration (shape) based on the specified source org",
   "create_shape_command_description_long": "Create a scratch org configuration (shape) based on the specified source org.",
   "create_shape_command_help": [
-    "sfdx force:org:shape:create -u me@my.org",
-    "sfdx force:org:shape:create -u me@my.org --json --loglevel debug"
+    "$ sfdx force:org:shape:create -u me@my.org",
+    "$ sfdx force:org:shape:create -u me@my.org --json --loglevel debug"
   ],
   "create_shape_command_username": "a username or alias for the target org",
   "create_shape_command_username_long": "Username or alias of the previously authorized org from which you want to create an org shape.",

--- a/messages/shape.delete.json
+++ b/messages/shape.delete.json
@@ -14,12 +14,12 @@
   "humanSuccess": "Successfully deleted org shape for %s.",
   "noShapesHumanSuccess": "Can't delete org shape. No org shape found for org %s.",
   "help": [
-    "sfdx force:org:shape:delete -u me@my.org",
+    "$ sfdx force:org:shape:delete -u me@my.org",
 
-    "sfdx force:org:shape:delete -u MyOrgAlias -p",
+    "$ sfdx force:org:shape:delete -u MyOrgAlias -p",
 
-    "sfdx force:org:shape:delete -u me@my.org --json",
+    "$ sfdx force:org:shape:delete -u me@my.org --json",
 
-    "sfdx force:org:shape:delete -u me@my.org -p --json > tmp/MyOrgShapeDelete.json"
+    "$ sfdx force:org:shape:delete -u me@my.org -p --json > tmp/MyOrgShapeDelete.json"
   ]
 }

--- a/messages/shape.list.json
+++ b/messages/shape.list.json
@@ -6,8 +6,8 @@
   "noOrgShapes": "No org shapes found.",
   "noAuthFound": "No authenticated orgs found.",
   "help": [
-    "sfdx force:org:shape:list",
-    "sfdx force:org:shape:list --json",
-    "sfdx force:org:shape:list --json > tmp/MyOrgShapeList.json"
+    "$ sfdx force:org:shape:list",
+    "$ sfdx force:org:shape:list --json",
+    "$ sfdx force:org:shape:list --json > tmp/MyOrgShapeList.json"
   ]
 }

--- a/messages/snapshot.create.json
+++ b/messages/snapshot.create.json
@@ -1,10 +1,10 @@
 {
   "description": "create a snapshot of a scratch org\nA snapshot is a point-in-time copy of a scratch org. The copy is stored in Salesforce and referenced by its unique name in a scratch org definition file.\n\nUse \"sfdx force:org:snapshot:get\" to get details, including status, about a snapshot creation request.\n\nTo create a scratch org from a snapshot, include the \"snapshot\" entry (instead of \"edition\") in the scratch org definition file and set it to the name of the snapshot. Then use \"sfdx force:org:create\" to create the scratch org.",
   "examples": [
-    "Create a snapshot called \"Dependencies\" using the source scratch org ID:\n",
-    "  sfdx force:org:snapshot:create --sourceorg 00Dxx0000000000 --snapshotname Dependencies --description 'Contains PackageA v1.1.0'\n",
-    "Create a snapshot called \"NightlyBranch\" using the source scratch org username:\n",
-    "  sfdx force:org:snapshot:create -o myuser@myorg -n NightlyBranch -d 'Contains PkgA v2.1.0 and PkgB 3.3.0'"
+    "Create a snapshot called \"Dependencies\" using the source scratch org ID:",
+    "$ sfdx force:org:snapshot:create --sourceorg 00Dxx0000000000 --snapshotname Dependencies --description 'Contains PackageA v1.1.0'",
+    "Create a snapshot called \"NightlyBranch\" using the source scratch org username:",
+    "$ sfdx force:org:snapshot:create -o myuser@myorg -n NightlyBranch -d 'Contains PkgA v2.1.0 and PkgB 3.3.0'"
   ],
   "flags": {
     "snapshotname": "unique name of snapshot",

--- a/messages/snapshot.delete.json
+++ b/messages/snapshot.delete.json
@@ -1,10 +1,10 @@
 {
   "description": "delete a scratch org snapshot\nDev Hub admins can delete any snapshot, while users can delete only theirs unless a Dev Hub admin gives the user Modify All permissions.",
   "examples": [
-    "Delete a snapshot from the default Dev Hub using the snapshot ID:\n",
-    "  sfdx force:org:snapshot:delete --snapshot 0Oo...\n", 
-    "Delete a snapshot from the specified Dev Hub using the snapshot name:\n",
-    "  sfdx force:org:snapshot:delete -s BaseSnapshot -v SnapshotDevHub"
+    "Delete a snapshot from the default Dev Hub using the snapshot ID:",
+    "$ sfdx force:org:snapshot:delete --snapshot 0Oo...", 
+    "Delete a snapshot from the specified Dev Hub using the snapshot name:",
+    "$ sfdx force:org:snapshot:delete -s BaseSnapshot -v SnapshotDevHub"
   ],
   "flags": {
     "snapshot": "name or ID of snapshot to delete"

--- a/messages/snapshot.get.json
+++ b/messages/snapshot.get.json
@@ -1,10 +1,10 @@
 {
   "description": "get details about a scratch org snapshot\nSnapshot creation can take a while. Use this command with the snapshot name or ID to check its creation status. Once the status changes to Active, you can use the snapshot to create scratch orgs. \n\nTo create a snapshot, use the \"sfdx force:org:snapshot:create\" command. To retrieve a list of all snapshots, use \"sfdx force:org:snapshot:list\".",
   "examples": [
-    "Get snapshot details using its ID:\n",
-    "  sfdx force:org:snapshot:get --snapshot 0Oo...\n",
-    "Get snapshot details using its name:\n",
-    "  sfdx force:org:snapshot:get -s Dependencies"
+    "Get snapshot details using its ID:",
+    "$ sfdx force:org:snapshot:get --snapshot 0Oo...",
+    "Get snapshot details using its name:",
+    "$ sfdx force:org:snapshot:get -s Dependencies"
   ],
   "flags": {
     "snapshot": "name or ID of snapshot to retrieve"

--- a/messages/snapshot.list.json
+++ b/messages/snapshot.list.json
@@ -1,9 +1,9 @@
 {
   "description": "list scratch org snapshots\nYou can view all the snapshots in a Dev Hub that you have access to. If you’re an admin, you can see all snapshots associated with the Dev Hub org. If you’re a user, you can see only your snapshots unless a Dev Hub admin gives you View All permissions.\n\nTo create a snapshot, use the \"sfdx force:org:snapshot:create\" command. To get details about a snapshot request, use \"sfdx force:org:snapshot:get\".",
   "examples": [
-    "List snapshots in the default Dev Hub:\n",
-    "  sfdx force:org:snapshot:list\n", 
-    "List snapshots in the Dev Hub with the specified username:\n",
-    "  sfdx force:org:snapshot:list -v OtherDevHub@example.com"
+    "List snapshots in the default Dev Hub:",
+    "$ sfdx force:org:snapshot:list", 
+    "List snapshots in the Dev Hub with the specified username:",
+    "$ sfdx force:org:snapshot:list -v OtherDevHub@example.com"
   ] 
 }


### PR DESCRIPTION
### What does this PR do?

Cleans up messages files for force:org:snapshot files because the command reference generator doesn't like their current format.

### What issues does this PR fix or reference?

@W-11152172@