### PR TITLE
fix(deps): dep bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "lib/index.js",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
-    "@oclif/core": "^2.7.1",
-    "@salesforce/core": "^3.34.6",
+    "@oclif/core": "^2.8.5",
+    "@salesforce/core": "^3.36.0",
     "@salesforce/kit": "^1.9.2",
     "@salesforce/sf-plugins-core": "^2.4.2",
     "chalk": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,7 +694,7 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@^2.0.7", "@oclif/core@^2.0.8", "@oclif/core@^2.1.2", "@oclif/core@^2.7.1", "@oclif/core@^2.8.0", "@oclif/core@^2.8.5":
+"@oclif/core@^2.0.7", "@oclif/core@^2.0.8", "@oclif/core@^2.1.2", "@oclif/core@^2.8.0", "@oclif/core@^2.8.2", "@oclif/core@^2.8.5":
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.8.5.tgz#7964057bbee5e91dae8b35e030e767f38e50a19e"
   integrity sha512-316DLfrHQDYmWDriI4Woxk9y1wVUrPN1sZdbQLHdOdlTA9v/twe7TdHpWOriEypfl6C85NWEJKc1870yuLtjrQ==


### PR DESCRIPTION
### What does this PR do?
bump core to get knowledge of new configs
RCA: JIT plugins don't benefit from the lockfile-dedupe that happens during CLI build, so it's possible for them to run old versions that don't tolerate the new configs.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2127
[@W-13189905@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001RCgi0YAD/view)