### PR TITLE
fix: update snapshot command state

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,16 +85,52 @@
         "description": "Commands to manage org shapes and snapshots.",
         "subtopics": {
           "create": {
-            "description": "Commands to create org shapes and snapshots."
+            "description": "Commands to create org shapes and snapshots.",
+            "subtopics": {
+              "snapshot": {
+                "state": "closedPilot",
+                "trailblazerCommunityLink": {
+                  "url": "https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A00000020d5",
+                  "name": "W19 Pilot: Scratch Org Snapshots"
+                }
+              }
+            }
           },
           "list": {
-            "description": "Commands to list org shapes and snapshots."
+            "description": "Commands to list org shapes and snapshots.",
+            "subtopics": {
+              "snapshot": {
+                "state": "closedPilot",
+                "trailblazerCommunityLink": {
+                  "url": "https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A00000020d5",
+                  "name": "W19 Pilot: Scratch Org Snapshots"
+                }
+              }
+            }
           },
           "delete": {
-            "description": " Commands to delete shapes and snapshots."
+            "description": " Commands to delete shapes and snapshots.",
+            "subtopics": {
+              "snapshot": {
+                "state": "closedPilot",
+                "trailblazerCommunityLink": {
+                  "url": "https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A00000020d5",
+                  "name": "W19 Pilot: Scratch Org Snapshots"
+                }
+              }
+            }
           },
           "get": {
-            "description": "Commands to get an org snapshot."
+            "description": "Commands to get an org snapshot.",
+            "subtopics": {
+              "snapshot": {
+                "state": "closedPilot",
+                "trailblazerCommunityLink": {
+                  "url": "https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A00000020d5",
+                  "name": "W19 Pilot: Scratch Org Snapshots"
+                }
+              }
+            }
           }
         }
       }

--- a/src/commands/org/create/snapshot.ts
+++ b/src/commands/org/create/snapshot.ts
@@ -23,6 +23,7 @@ export class SnapshotCreate extends SfCommand<OrgSnapshot> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:snapshot:create'];
   public static readonly deprecateAliases = true;
+  public static readonly state = 'closedPilot';
   public static readonly flags = {
     'target-dev-hub': requiredHubFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,

--- a/src/commands/org/delete/snapshot.ts
+++ b/src/commands/org/delete/snapshot.ts
@@ -28,6 +28,7 @@ export class SnapshotDelete extends SfCommand<SaveResult> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:snapshot:delete'];
   public static readonly deprecateAliases = true;
+  public static readonly state = 'closedPilot';
 
   public static readonly flags = {
     'target-dev-hub': requiredHubFlagWithDeprecations,

--- a/src/commands/org/get/snapshot.ts
+++ b/src/commands/org/get/snapshot.ts
@@ -23,6 +23,7 @@ export class SnapshotGet extends SfCommand<OrgSnapshot> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:snapshot:get'];
   public static readonly deprecateAliases = true;
+  public static readonly state = 'closedPilot';
 
   public static readonly flags = {
     'target-dev-hub': requiredHubFlagWithDeprecations,

--- a/src/commands/org/list/snapshot.ts
+++ b/src/commands/org/list/snapshot.ts
@@ -22,6 +22,7 @@ export class SnapshotList extends SfCommand<OrgSnapshot[]> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:snapshot:list'];
   public static readonly deprecateAliases = true;
+  public static readonly state = 'closedPilot';
   public static readonly flags = {
     'target-dev-hub': requiredHubFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,


### PR DESCRIPTION
### What does this PR do?
updates `org * snapshot` cmd state, this will only affect the [CLI command reference site](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_top.htm)

plugin-command-reference
https://github.com/search?q=repo%3Asalesforcecli%2Fplugin-command-reference%20closedPilot&type=code

### What issues does this PR fix or reference?
@W-13756410@