### PR TITLE
fix: Remove LastClonedBy and LastClonedDate fields from Snapshot

### DIFF
--- a/src/shared/snapshot.ts
+++ b/src/shared/snapshot.ts
@@ -22,8 +22,6 @@ export interface OrgSnapshotRequest {
 export type OrgSnapshot = OrgSnapshotRequest & {
   Id: string;
   Status: string;
-  LastClonedDate?: string;
-  LastClonedById?: string;
   CreatedDate: string;
   LastModifiedDate: string;
   ExpirationDate?: string;
@@ -39,8 +37,6 @@ export const ORG_SNAPSHOT_FIELDS = [
   'CreatedDate',
   'LastModifiedDate',
   'ExpirationDate',
-  'LastClonedDate',
-  'LastClonedById',
   'Error',
 ];
 const dateTimeFormatter = (dateString?: string): string =>
@@ -73,11 +69,6 @@ const ORG_SNAPSHOT_COLUMNS = {
     header: 'Expiration Date',
     get: (row: OrgSnapshot): string => (row.ExpirationDate ? new Date(row.ExpirationDate).toLocaleDateString() : ''),
   },
-  LastClonedDate: {
-    header: 'Last Cloned Date',
-    get: (row: OrgSnapshot): string => rowDateTimeFormatter(row, 'LastClonedDate'),
-  },
-  LastClonedById: { header: 'Last Cloned By Id', get: (row: OrgSnapshot): string => row.LastClonedById ?? '' },
 };
 
 const invalidTypeErrorHandler = (e: unknown): never => {
@@ -122,7 +113,7 @@ export const printSingleRecordTable = (snapshotRecord: OrgSnapshot): void => {
       .map(([key, value]: [string, string]) => ({
         Name: capitalCase(key),
         // format the datetime values
-        Value: ['LastModifiedDate', 'LastClonedDate', 'CreatedDate'].includes(key) ? dateTimeFormatter(value) : value,
+        Value: ['LastModifiedDate', 'CreatedDate'].includes(key) ? dateTimeFormatter(value) : value,
       }))
       // null/undefined becomes empty string
       .map((row) => (row.Value ? row : { ...row, Value: '' })),

--- a/test/nuts/snapshots.nut.ts
+++ b/test/nuts/snapshots.nut.ts
@@ -104,9 +104,7 @@ describe('snapshot commands', () => {
       ensureExitCode: 0,
     }).shellOutput.stdout;
     expect(table).to.include('Snapshot Name');
-    expect(table).to.include('Last Cloned Date');
     expect(table).to.not.include('SnapshotName');
-    expect(table).to.not.include('LastClonedDate');
 
     // time fixes
     expect(table).not.to.include('.000+0000');
@@ -133,9 +131,7 @@ describe('snapshot commands', () => {
       ensureExitCode: 0,
     }).shellOutput.stdout;
     expect(table).to.include('Snapshot Name');
-    expect(table).to.include('Last Cloned Date');
     expect(table).to.not.include('SnapshotName');
-    expect(table).to.not.include('LastClonedDate');
 
     // time fixes
     expect(table).not.to.include('.000+0000');


### PR DESCRIPTION
### What does this PR do?

Removes references to the `LastClonedBy` and `LastClonedDate` fields from the OrgSnapshot object.

### What issues does this PR fix or reference?

None (yet)

[skip-validate-pr]