### PR TITLE
Revert "feat: add a prompt for snapshot deletion (#567)"

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -27,8 +27,8 @@
     "alias": ["force:org:snapshot:delete"],
     "command": "org:delete:snapshot",
     "flagAliases": ["apiversion", "targetdevhubusername"],
-    "flagChars": ["p", "s", "v"],
-    "flags": ["api-version", "flags-dir", "json", "loglevel", "no-prompt", "snapshot", "target-dev-hub"],
+    "flagChars": ["s", "v"],
+    "flags": ["api-version", "flags-dir", "json", "loglevel", "snapshot", "target-dev-hub"],
     "plugin": "@salesforce/plugin-signups"
   },
   {

--- a/messages/snapshot.delete.md
+++ b/messages/snapshot.delete.md
@@ -24,14 +24,6 @@ Name or ID of snapshot to delete.
 
 The IDs of scratch org snapshots start with 0Oo.
 
-# flags.no-prompt.summary
-
-Don't prompt the user to confirm the deletion.
-
-# prompt.confirm
-
-Are you sure you want to delete the snapshot with name: %s?
-
 # success
 
 Successfully deleted snapshot %s.

--- a/src/commands/org/delete/snapshot.ts
+++ b/src/commands/org/delete/snapshot.ts
@@ -23,7 +23,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-signups', 'snapshot.d
 // jsforce can return SaveError[] or never[]
 const isSaveError = (error: SaveError): error is SaveError => error.message !== undefined;
 
-export class SnapshotDelete extends SfCommand<SaveResult | undefined> {
+export class SnapshotDelete extends SfCommand<SaveResult> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
@@ -41,20 +41,11 @@ export class SnapshotDelete extends SfCommand<SaveResult | undefined> {
       description: messages.getMessage('flags.snapshot.description'),
       required: true,
     }),
-    'no-prompt': Flags.boolean({
-      char: 'p',
-      summary: messages.getMessage('flags.no-prompt.summary'),
-    }),
   };
 
-  public async run(): Promise<SaveResult | undefined> {
-    const { flags } = await this.parse(SnapshotDelete);
-    const snapshot = flags['snapshot'];
-    if (!flags['no-prompt'] && !(await this.confirm({ message: messages.getMessage('prompt.confirm', [snapshot]) }))) {
-      return;
-    }
-
+  public async run(): Promise<SaveResult> {
     // resolve the query to an ID.  This also verifies the snapshot exists in the org
+    const { flags } = await this.parse(SnapshotDelete);
     const conn = flags['target-dev-hub'].getConnection(flags['api-version']);
     const result = await queryByNameOrId(conn, flags.snapshot);
     const deleteResult = await conn.sobject('OrgSnapshot').delete(result.Id);

--- a/test/nuts/snapshots.nut.ts
+++ b/test/nuts/snapshots.nut.ts
@@ -137,26 +137,26 @@ describe('snapshot commands', () => {
     expect(table).not.to.include('.000+0000');
   });
 
-  it('can delete a snapshot by id (no prompt)', () => {
-    execCmd(`force:org:snapshot:delete -s ${aliasSnapshot.Id} --json --no-prompt`, {
+  it('can delete a snapshot by id', () => {
+    execCmd(`force:org:snapshot:delete -s ${aliasSnapshot.Id} --json`, {
       ensureExitCode: 0,
     });
   });
 
-  it('can delete a snapshot by name (no prompt)', () => {
-    execCmd(`force:org:snapshot:delete -s ${orgIdSnapshot.SnapshotName} --json --no-prompt`, {
+  it('can delete a snapshot by name', () => {
+    execCmd(`force:org:snapshot:delete -s ${orgIdSnapshot.SnapshotName} --json`, {
       ensureExitCode: 0,
     });
   });
 
-  it('can delete the last snapshot by name (no prompt)', () => {
-    execCmd(`force:org:snapshot:delete -s ${usernameSnapshot.SnapshotName} --json --no-prompt`, {
+  it('can delete the last snapshot by name', () => {
+    execCmd(`force:org:snapshot:delete -s ${usernameSnapshot.SnapshotName} --json`, {
       ensureExitCode: 0,
     });
   });
 
-  it('fails at deleting the same snapshot twice (no prompt)', () => {
-    execCmd(`force:org:snapshot:delete -s ${usernameSnapshot.SnapshotName} --json --no-prompt`, {
+  it('fails at deleting the same snapshot twice', () => {
+    execCmd(`force:org:snapshot:delete -s ${usernameSnapshot.SnapshotName} --json`, {
       ensureExitCode: 1,
     });
   });


### PR DESCRIPTION
This reverts commit 3ad43fb6adf1bb481162421d64f3772551394771.

### What does this PR do?
Reverts changes done in #567, see: https://github.com/salesforcecli/plugin-signups/pull/567#issuecomment-2096379145

The new behavior breaks scripts running `org delete snapshot` (prompts for confirmation, defaults to `No` unless you pass `y` or `--no-prompt`).

This change should go through our CLI deprecation policy:
https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_deprecation.htm

specifically, adding a warning to `org delete snapshot` mentioning that it will prompt for confirmation in a future release (at least 4 months by our policy).

### What issues does this PR fix or reference?
[skip-validate-PR]