### PR TITLE
fix: update messages to doc "org create scratch"

### DIFF
--- a/messages/shape.create.md
+++ b/messages/shape.create.md
@@ -8,7 +8,7 @@ Scratch org shapes mimic the baseline setup (features, limits, edition, and Meta
 
 Run "<%= config.bin %> org list shape" to view the available org shapes and their IDs.
 
-To create a scratch org from an org shape, include the "sourceOrg" property in the scratch org definition file and set it to the org ID of the source org. Then create a scratch org with the "<%= config.bin %> force:org:create" command.
+To create a scratch org from an org shape, include the "sourceOrg" property in the scratch org definition file and set it to the org ID of the source org. Then create a scratch org with the "<%= config.bin %> org create scratch" command.
 
 # examples
 

--- a/messages/snapshot.create.md
+++ b/messages/snapshot.create.md
@@ -8,7 +8,7 @@ A snapshot is a point-in-time copy of a scratch org. The copy is referenced by i
 
 Use "<%= config.bin %> org get snapshot" to get details, including status, about a snapshot creation request.
 
-To create a scratch org from a snapshot, include the "snapshot" option (instead of "edition") in the scratch org definition file and set it to the name of the snapshot. Then use "<%= config.bin %> force:org:create" to create the scratch org.
+To create a scratch org from a snapshot, include the "snapshot" option (instead of "edition") in the scratch org definition file and set it to the name of the snapshot. Then use "<%= config.bin %> org create scratch" to create the scratch org.
 
 # examples
 


### PR DESCRIPTION
### What does this PR do?

Update the messages for the "org create snapshot" and "org create shape" commands to reference the "org create scratch" command (rather than deprecated "force:org:create" command)

### What issues does this PR fix or reference?
@W-15875008@