### PR TITLE
feat: removing beta marking @w-14636241@

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "@salesforce/core": "^8.0.1",
     "@salesforce/kit": "^3.1.6",
     "@salesforce/sf-plugins-core": "^11.1.2",
-    "change-case": "^5.4.4",
-    "gulp": "^5.0.0"
+    "change-case": "^5.4.4"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "@salesforce/core": "^8.0.1",
     "@salesforce/kit": "^3.1.6",
     "@salesforce/sf-plugins-core": "^11.1.2",
-    "change-case": "^5.4.4"
+    "change-case": "^5.4.4",
+    "gulp": "^5.0.0"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.2.3",
@@ -62,52 +63,16 @@
         "description": "Commands to manage org shapes and snapshots.",
         "subtopics": {
           "create": {
-            "description": "Commands to create org shapes and snapshots.",
-            "subtopics": {
-              "snapshot": {
-                "state": "beta",
-                "trailblazerCommunityLink": {
-                  "url": "https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A00000020d5",
-                  "name": "W24 Beta: Scratch Org Snapshots"
-                }
-              }
-            }
+            "description": "Commands to create org shapes and snapshots."
           },
           "list": {
-            "description": "Commands to list org shapes and snapshots.",
-            "subtopics": {
-              "snapshot": {
-                "state": "beta",
-                "trailblazerCommunityLink": {
-                  "url": "https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A00000020d5",
-                  "name": "W24 Beta: Scratch Org Snapshots"
-                }
-              }
-            }
+            "description": "Commands to list org shapes and snapshots."
           },
           "delete": {
-            "description": " Commands to delete shapes and snapshots.",
-            "subtopics": {
-              "snapshot": {
-                "state": "beta",
-                "trailblazerCommunityLink": {
-                  "url": "https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A00000020d5",
-                  "name": "W24 Beta: Scratch Org Snapshots"
-                }
-              }
-            }
+            "description": "Commands to delete shapes and snapshots."
           },
           "get": {
-            "description": "Commands to get an org snapshot.",
-            "subtopics": {
-              "snapshot": {
-                "state": "beta",
-                "trailblazerCommunityLink": {
-                  "url": "https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A00000020d5",
-                  "name": "W24 Beta: Scratch Org Snapshots"
-                }
-              }
-            }
+            "description": "Commands to get an org snapshot."
           }
         }
       }

--- a/src/commands/org/create/snapshot.ts
+++ b/src/commands/org/create/snapshot.ts
@@ -30,7 +30,6 @@ export class SnapshotCreate extends SfCommand<OrgSnapshot> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:snapshot:create'];
   public static readonly deprecateAliases = true;
-  public static readonly state = 'beta';
   public static readonly flags = {
     'target-dev-hub': requiredHubFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,

--- a/src/commands/org/delete/snapshot.ts
+++ b/src/commands/org/delete/snapshot.ts
@@ -29,7 +29,6 @@ export class SnapshotDelete extends SfCommand<SaveResult | undefined> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:snapshot:delete'];
   public static readonly deprecateAliases = true;
-  public static readonly state = 'beta';
 
   public static readonly flags = {
     'target-dev-hub': requiredHubFlagWithDeprecations,

--- a/src/commands/org/get/snapshot.ts
+++ b/src/commands/org/get/snapshot.ts
@@ -24,7 +24,6 @@ export class SnapshotGet extends SfCommand<OrgSnapshot> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:snapshot:get'];
   public static readonly deprecateAliases = true;
-  public static readonly state = 'beta';
 
   public static readonly flags = {
     'target-dev-hub': requiredHubFlagWithDeprecations,

--- a/src/commands/org/list/snapshot.ts
+++ b/src/commands/org/list/snapshot.ts
@@ -23,7 +23,6 @@ export class SnapshotList extends SfCommand<OrgSnapshot[]> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly aliases = ['force:org:snapshot:list'];
   public static readonly deprecateAliases = true;
-  public static readonly state = 'beta';
   public static readonly flags = {
     'target-dev-hub': requiredHubFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,


### PR DESCRIPTION
### What does this PR do?

This PR removes text marking the snapshot commends as BETA. They are going to be considered GA code as of 07/10/2024

### What issues does this PR fix or reference?

Mislabelling commands as BETA.

Reference @W-14636241@(https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001g9SMQYA2/view)